### PR TITLE
Cleanup linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_build
+c_src/longfi-core
+priv

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -34,10 +34,10 @@ else ifeq ($(UNAME_SYS), Linux)
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 endif
 
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I longfi-core/include/lfc
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I longfi-core/install/include
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei -L longfi-core/build/src -L longfi-core/build/_deps/cursor-build/src -L longfi-core/build/extra/cursor_varint -L longfi-core/build/extra/blake2 -L longfi-core/build/extra/golay -llfc -lgolay -lblake2 -lcursor -lcursor_varint
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei -L longfi-core/install/lib -llfc -lgolay -lblake2 -lcursor -lcursor_varint
 LDFLAGS += -shared
 
 # Verbosity.

--- a/c_src/compile.sh
+++ b/c_src/compile.sh
@@ -17,7 +17,6 @@ if [ ! "$VERSION" = "$CURRENT_VERSION" ]; then
     git checkout $VERSION
 fi
 
-if [ ! -d build ]; then
-    cmake -H. -Bbuild -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-fi
-make -C build -j
+cmake -H. -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+cmake --build . -j
+cmake --install .

--- a/c_src/longfi.c
+++ b/c_src/longfi.c
@@ -15,8 +15,8 @@
  */
 
 #include "erl_nif.h"
-#include "lfc.h"
-#include "fingerprint.h"
+#include "lfc/lfc.h"
+#include "lfc/fingerprint.h"
 #include <stdbool.h>
 #include <string.h>
 


### PR DESCRIPTION
We can cut out a little noise by installing `longfi-core` to a local root and using that location as a unified place to find headers and archives.

