### PR TITLE
Properly find gnumake on some platforms.

### DIFF
--- a/c_src/compile.sh
+++ b/c_src/compile.sh
@@ -7,6 +7,8 @@ if [ ! -d c_src/longfi-core ]; then
     git clone https://github.com/helium/longfi-core.git c_src/longfi-core
 fi
 
+MAKE=$( which gmake ) || MAKE=make
+
 cd c_src/longfi-core
 
 CURRENT_VERSION=`git describe --tags`
@@ -17,7 +19,11 @@ if [ ! "$VERSION" = "$CURRENT_VERSION" ]; then
     git checkout $VERSION
 fi
 
+export CFLAGS=-fPIC
+export LDFLAGS=-fPIC
+
 if [ ! -d build ]; then
     cmake -H. -Bbuild -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 fi
-make -C build -j
+
+${MAKE} -C build -j

--- a/c_src/compile.sh
+++ b/c_src/compile.sh
@@ -19,9 +19,6 @@ if [ ! "$VERSION" = "$CURRENT_VERSION" ]; then
     git checkout $VERSION
 fi
 
-export CFLAGS=-fPIC
-export LDFLAGS=-fPIC
-
 if [ ! -d build ]; then
     cmake -H. -Bbuild -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 fi


### PR DESCRIPTION
This project's Makefile is for GNUMake only so it is important to find GNUMake
on the build host. It may not be the default `make` for the platform.